### PR TITLE
Update CODE-OF-CONDUCT.md

### DIFF
--- a/docs/CODE-OF-CONDUCT.md
+++ b/docs/CODE-OF-CONDUCT.md
@@ -10,7 +10,7 @@ Examples of unacceptable behavior by participants include:
 - Personal attacks
 - Trolling or insulting/derogatory comments
 - Public or private harassment
-- Publishing other’s private information, such as physical or electronic addresses, without explicit permission
+- Publishing others' private information, such as physical or electronic addresses, without explicit permission
 - Other unethical or unprofessional conduct
 - Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 


### PR DESCRIPTION
As here, we are referring to the audience(plural), it should be (others') in place of (other's).

### What does this PR do?
> Update the word

### Description
> Since we are talking about multiple others ("...the addresses of others"), then the apostrophe comes after the s.

### Screenshots or Links
> Null

### Additional context
> Null

### Checklist:
- [x] Read our [contributing guidelines](../docs/CONTRIBUTING.md).
- [x] Search for duplicates.
- [x] Used an informative name for this pull request.

### Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
