### PR TITLE
fixed a typo in html cheatsheet

### DIFF
--- a/CheatSheets/html-cheatsheet.md
+++ b/CheatSheets/html-cheatsheet.md
@@ -97,7 +97,7 @@ created: 2022-10-20
 | `<strong> ... </strong>` | Defines important text                               |
 | `<sub> ... </sub>`       | Defines subscripted text                             |
 | `<sup> ... </sup>`       | Defines superscripted text                           |
-| `<ins> ... </i>`         | Defines inserted text                                |
+| `<ins> ... </ins>`       | Defines inserted text                                |
 | `<del> ... </del>`       | Defines deleted text                                 |
 | `<mark> ... </mark>`     | Defines marked/highlighted text                      |
 


### PR DESCRIPTION
### What does this PR do?
>  Bug fix

### Description
> In the formatting section in html cheatsheet, closing tag for `<ins>` should be `</ins>` instead of `</i>`. I fixed it with appropriate closing tag.

### Screenshots or Links
> If applicable, add `screenshots` or a modified `UI link` to help understand your contribution.

### Additional context
> Add any other context about your PR.

### Checklist:
- [x] Read our [contributing guidelines](../docs/CONTRIBUTING.md).
- [x] Search for duplicates.
- [x] Used an informative name for this pull request.

### Follow-up
- Check the status of GitHub Actions and resolve any reported warnings!
