### PR TITLE
Add new cheat sheets for Ansible and Jenkins

### DIFF
--- a/CheatSheets/Ansible_CheatSheet.md
+++ b/CheatSheets/Ansible_CheatSheet.md
@@ -1,0 +1,124 @@
+---
+title: Ansible CheatSheet
+description: The most commonly used Ansible commands are given here.
+created: 2026-01-27
+---
+
+## Table of Contents
+
+- [Ansible CheatSheet for Developers](#ansible-cheatsheet-for-developers)
+  - [Check Ansible Setup and Configuration](#check-ansible-setup-and-configuration)
+  - [Inventory and Connectivity](#inventory-and-connectivity)
+  - [Running Ad-hoc Commands](#running-ad-hoc-commands)
+  - [Playbooks](#playbooks)
+  - [Roles](#roles)
+  - [Variables and Facts](#variables-and-facts)
+  - [Ansible Galaxy](#ansible-galaxy)
+  - [Ansible Vault](#ansible-vault)
+  - [Miscellaneous Commands](#miscellaneous-commands)
+
+# Ansible CheatSheet for Developers
+
+## Check Ansible Setup and Configuration
+
+| Command                         | Description                                              |
+| :-----------------------------: | -------------------------------------------------------- |
+| `ansible --version`             | Display Ansible version and configuration paths          |
+| `ansible-config list`           | List all Ansible configuration options                   |
+| `ansible-config view`           | View the active Ansible configuration                    |
+| `ansible-doc -l`                | List all available Ansible modules                       |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Inventory and Connectivity
+
+| Command                                               | Description                                               |
+| :---------------------------------------------------: | --------------------------------------------------------- |
+| `ansible all -i inventory -m ping`                    | Test connectivity to all hosts                            |
+| `ansible all -m ping`                                 | Ping all hosts using default inventory                    |
+| `ansible web -i inventory -m ping`                    | Ping hosts in the `web` group                             |
+| `ansible-inventory --list -y`                         | Display inventory in YAML format                          |
+| `ansible-inventory --graph`                           | Display inventory as a graph                              |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Running Ad-hoc Commands
+
+| Command                                                             | Description                                              |
+| :-----------------------------------------------------------------: | -------------------------------------------------------- |
+| `ansible all -m shell -a "uptime"`                                   | Run shell command on all hosts                           |
+| `ansible web -m command -a "df -h"`                                  | Run command module on `web` hosts                        |
+| `ansible all -m copy -a "src=a.txt dest=/tmp/a.txt"`                | Copy file to remote hosts                                |
+| `ansible all -m yum -a "name=httpd state=present" -b`               | Install package using privilege escalation               |
+| `ansible all -m service -a "name=httpd state=started" -b`           | Start a service                                          |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Playbooks
+
+| Command                                         | Description                                               |
+| :---------------------------------------------: | --------------------------------------------------------- |
+| `ansible-playbook site.yml`                     | Run a playbook                                           |
+| `ansible-playbook site.yml -i inventory`        | Run playbook with specific inventory                     |
+| `ansible-playbook site.yml --check`             | Dry run (check mode)                                     |
+| `ansible-playbook site.yml --diff`              | Show differences when files change                       |
+| `ansible-playbook site.yml -l web`              | Limit execution to `web` hosts                            |
+| `ansible-playbook site.yml -t install`          | Run tasks with specific tag                               |
+| `ansible-playbook site.yml --start-at-task "X"` | Start execution from a specific task                     |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Roles
+
+| Command                                   | Description                                         |
+| :---------------------------------------: | --------------------------------------------------- |
+| `ansible-galaxy init my_role`             | Create a new role structure                         |
+| `ansible-galaxy list`                     | List installed roles                                |
+| `ansible-galaxy install nginxinc.nginx`   | Install role from Ansible Galaxy                   |
+| `ansible-galaxy remove nginxinc.nginx`    | Remove an installed role                            |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Variables and Facts
+
+| Command                                               | Description                                               |
+| :---------------------------------------------------: | --------------------------------------------------------- |
+| `ansible all -m setup`                                | Gather facts from all hosts                               |
+| `ansible all -m setup -a "filter=ansible_os_family"`  | Filter specific facts                                     |
+| `ansible-playbook site.yml -e "env=prod"`             | Pass extra variables via CLI                              |
+| `ansible-playbook site.yml -e @vars.yml`              | Load variables from a file                                |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Ansible Galaxy
+
+| Command                                       | Description                                           |
+| :-------------------------------------------: | ----------------------------------------------------- |
+| `ansible-galaxy search mysql`                 | Search roles on Ansible Galaxy                        |
+| `ansible-galaxy install geerlingguy.mysql`    | Install role from Galaxy                              |
+| `ansible-galaxy collection list`              | List installed collections                            |
+| `ansible-galaxy collection install community.aws` | Install a collection                             |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Ansible Vault
+
+| Command                                      | Description                                           |
+| :------------------------------------------: | ----------------------------------------------------- |
+| `ansible-vault create secrets.yml`           | Create an encrypted file                              |
+| `ansible-vault edit secrets.yml`             | Edit an encrypted file                                |
+| `ansible-vault encrypt vars.yml`              | Encrypt an existing file                              |
+| `ansible-vault decrypt vars.yml`              | Decrypt a file                                        |
+| `ansible-playbook site.yml --ask-vault-pass` | Run playbook with vault password prompt               |
+
+**[🔼Back to Top](#table-of-contents)**
+
+## Miscellaneous Commands
+
+| Command                                   | Description                                             |
+| :---------------------------------------: | ------------------------------------------------------- |
+| `ansible-doc yum`                         | Show documentation for a module                         |
+| `ansible-playbook site.yml -vvv`          | Run playbook with verbose output                        |
+| `ansible localhost -m debug -a "var=hostvars"` | Debug variables                                   |
+
+**[🔼Back to Top](#table-of-contents)**

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -88,6 +88,7 @@ created: 2022-10-22
 | `docker system prune --all --force` | Removes everything that is not in use  |
 | `docker builder prune` | Removes build cache  |
 | `docker container prune` | Remove stopped containers  |
+| `docker network create traefik-public` | Create docker network named "traefik-public"  |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -9,6 +9,7 @@ created: 2022-10-22
 - [Docker CheatSheet for Developers](#docker-cheatsheet-for-developers)
   - [Run a New Container](#run-a-new-container) 
   - [Manage Containers](#manage-containers)
+  - [Manage Compose](#manage-compose)
   - [Manage Images](#manage-images)
   - [Manage System](#manage-system)
   - [Info and Stats](#info-and-stats)
@@ -54,6 +55,7 @@ created: 2022-10-22
 
 | Command                                   | Description                              |
 | --------------------------------------    | ---------------------------------------- |
+| `docker compose build --no-cache`         | Build docker compose with no-cache       |
 | `docker compose ls`                       | Show a list of running compose           |
 | `docker compose up -d --force-recreate`   | Down and again up existing compose       |
 | `docker compose -p <project_name> down`   | Down compose from any directory          |

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -98,6 +98,7 @@ created: 2022-10-22
 | `docker inspect NAME`   | Get detailed info about an object      |
 | `docker diff CONTAINER` | Show all modified files in a container |
 | `docker port CONTAINER` | Show mapped ports of a container       |
+| `docker system df`      | Show storage usage in docker           |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -55,7 +55,8 @@ created: 2022-10-22
 | Command                                   | Description                              |
 | --------------------------------------    | ---------------------------------------- |
 | `docker compose ls`                       | Show a list of running compose           |
-| `docker compose up -d --force-recreate`   | Down and again up existing containers    |
+| `docker compose up -d --force-recreate`   | Down and again up existing compose       |
+| `docker compose -p <project_name> down`   | Down compose from any directory          |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -50,6 +50,14 @@ created: 2022-10-22
 
 **[🔼Back to Top](#table-of-contents)**
 
+## Manage Compose
+
+| Command                                | Description                              |
+| -------------------------------------- | ---------------------------------------- |
+| `docker compose ls`                            | Show a list of running compose        |
+
+**[🔼Back to Top](#table-of-contents)**
+
 ## Manage Images
 
 | Command                           | Description                              |

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -53,12 +53,13 @@ created: 2022-10-22
 
 ## Manage Compose
 
-| Command                                   | Description                              |
-| --------------------------------------    | ---------------------------------------- |
-| `docker compose build --no-cache`         | Build docker compose with no-cache       |
-| `docker compose ls`                       | Show a list of running compose           |
-| `docker compose up -d --force-recreate`   | Down and again up existing compose       |
-| `docker compose -p <project_name> down`   | Down compose from any directory          |
+| Command                                                                     | Description                              |
+| --------------------------------------                                      | ---------------------------------------- |
+| `docker compose build --no-cache`                                           | Build docker compose with no-cache       |
+| `docker compose ls`                                                         | Show a list of running compose           |
+| `docker compose up -d --force-recreate`                                     | Down and again up existing compose       |
+| `docker compose -p <project_name> down`                                     | Down compose from any directory          |
+| `docker-compose -f docker-compose.yml -f docker-compose.traefik.yml up -d`  | Up docker compose with custom overide file(default overide will not effect) |         |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -90,6 +90,7 @@ created: 2022-10-22
 | `docker builder prune` | Removes build cache  |
 | `docker container prune` | Remove stopped containers  |
 | `docker network create traefik-public` | Create docker network named "traefik-public"  |
+| `docker network rm <network_name_or_id>` | Remove docker network |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -82,6 +82,8 @@ created: 2022-10-22
 | Command                           | Description                              |
 | --------------------------------- | ---------------------------------------- |
 | `docker system prune --all --force` | Removes everything that is not in use  |
+| `docker builder prune` | Removes build cache  |
+| `docker container prune` | Remove stopped containers  |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -52,9 +52,10 @@ created: 2022-10-22
 
 ## Manage Compose
 
-| Command                                | Description                              |
-| -------------------------------------- | ---------------------------------------- |
-| `docker compose ls`                            | Show a list of running compose        |
+| Command                                   | Description                              |
+| --------------------------------------    | ---------------------------------------- |
+| `docker compose ls`                       | Show a list of running compose           |
+| `docker compose up -d --force-recreate`   | Down and again up existing containers    |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -84,13 +84,15 @@ created: 2022-10-22
 
 ## Manage System
 
-| Command                           | Description                              |
-| --------------------------------- | ---------------------------------------- |
-| `docker system prune --all --force` | Removes everything that is not in use  |
-| `docker builder prune` | Removes build cache  |
-| `docker container prune` | Remove stopped containers  |
-| `docker network create traefik-public` | Create docker network named "traefik-public"  |
-| `docker network rm <network_name_or_id>` | Remove docker network |
+| Command | Description |
+| ------- | ----------- |
+| `docker system prune --all --force` | Removes everything that is not in use |
+| `docker builder prune` | Removes build cache |
+| `docker container prune` | Removes stopped containers |
+| `docker network create traefik-public` | Creates a Docker network named **traefik-public** |
+| `docker network rm <network_name_or_id>` | Removes a Docker network |
+| `sudo systemctl stop docker && sudo rm -rf /var/lib/docker/* && sudo systemctl start docker` | Performs a **clean reset** of Docker (⚠ removes everything) |
+
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -58,6 +58,7 @@ created: 2022-10-22
 | `docker compose build --no-cache`                                           | Build docker compose with no-cache       |
 | `docker compose ls`                                                         | Show a list of running compose           |
 | `docker compose up -d --force-recreate`                                     | Down and again up existing compose       |
+| `docker-compose --env-file .env.server --env-file .env up -d --build`                                     | Up docker compose with env file       |
 | `docker compose -p <project_name> down`                                     | Down compose from any directory          |
 | `docker-compose -f docker-compose.yml -f docker-compose.traefik.yml up -d`  | Up docker compose with custom overide file(default overide will not effect) |         |
 

--- a/CheatSheets/docker-cheatsheet.md
+++ b/CheatSheets/docker-cheatsheet.md
@@ -91,7 +91,7 @@ created: 2022-10-22
 | `docker container prune` | Removes stopped containers |
 | `docker network create traefik-public` | Creates a Docker network named **traefik-public** |
 | `docker network rm <network_name_or_id>` | Removes a Docker network |
-| `sudo systemctl stop docker && sudo rm -rf /var/lib/docker/* && sudo systemctl start docker` | Performs a **clean reset** of Docker (⚠ removes everything) |
+| `sudo systemctl stop docker && sudo rm -rf /var/lib/docker && sudo rm -rf /var/lib/containerd && sudo systemctl start docker` | Performs a **clean reset** of Docker (⚠ removes everything) |
 
 
 **[🔼Back to Top](#table-of-contents)**

--- a/CheatSheets/git-cheatsheet.md
+++ b/CheatSheets/git-cheatsheet.md
@@ -177,6 +177,8 @@ created: 2022-10-18
 | `git reset --soft "commit-hash"` | Take my changes and go back/kill the commit I made but the file will be staged with the change ready to be committed again |
 | `git reset --mixed "commit-hash"` | Return/Kill the commit too but it returns the files to before staged i.e. modified but it will still return |
 | `git reset --hard "commit-hash"` | It will simply ignore the existence of this commit and undo everything that was done in this commit. <br /> It is a very rough reset and is normally used before pushing your commit to the remote repository. |
+| `git reset --hard HEAD~1
+git push --force"` | If you already pushed and want to rewrite history |
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/git-cheatsheet.md
+++ b/CheatSheets/git-cheatsheet.md
@@ -35,6 +35,13 @@ created: 2022-10-18
 | `git config --global core.editor vim` | Configure editor | 
 | `git config user.name` | List username | 
 | `git config user.email` | List email | 
+| `git config --local user.name "Your Name"` | Configure username for current repository |
+| `git config --global init.defaultBranch main` | Set default branch name |
+| `git config --global color.ui auto` | Enable colored output |
+| `git config --global --unset user.name` | Remove a Configuration |
+| `git config --global --edit` | Open global config file |
+| `git config --global --list --show-origin` | Check Git Config File Location |
+
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/CheatSheets/jenkins-cheatsheet.md
+++ b/CheatSheets/jenkins-cheatsheet.md
@@ -1,0 +1,21 @@
+---
+title: Jenkins CheatSheet
+description: The most commonly used jenkins commands are given here.
+created: 2022-10-22
+---
+
+## Table of Contents
+
+- [Jenkins CheatSheet for Developers](#docker-cheatsheet-for-developers)
+  - [Manage Jenkins on Linux](#manage-jenkins-on-linux) 
+
+
+# Jenkins CheatSheet for Developers
+
+## Manage Jenkins on Linux 
+
+| Command                                        | Description                              |
+| ---------------------------------------------- | ---------------------------------------- |
+| `sudo systemctl restart jenkins`               | Restart Jenkins on Linux Server      |
+
+**[🔼Back to Top](#table-of-contents)**

--- a/CheatSheets/linux-cheatsheet.md
+++ b/CheatSheets/linux-cheatsheet.md
@@ -142,6 +142,8 @@ created: 2022-10-21
 | `fdisk -l` | Display disks partitions sizes and types|
 | `du -ah` | Display disk usage for all files and directories in human readable format|
 | `du -sh` | Display total disk usage off the current directory|
+| `sudo apt-get install ncdu` | Install text based storage vizualizer|
+| `sudo ncdu /` | Vizualize storage|
 
 **[🔼Back to Top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A Collection of programming [CheatSheets](./CheatSheets/) for developers to quic
 | __[docker-cheatsheet.md](./CheatSheets/docker-cheatsheet.md)__ | __[terraform-cheatsheet.md](./CheatSheets/terraform-cheatsheet.md)__ | __[regex-cheatsheet.md](./CheatSheets/regex-cheatsheet.md)__ |
 | __[conda-cheatsheet.md](./CheatSheets/conda-cheatsheet.md)__ | __[pandas-cheatsheet.md](./CheatSheets/pandas-cheatsheet.md)__ | __[numpy-cheatsheet.md](./CheatSheets/Numpy-cheatsheet.md)__ |
 | __[configure-react-cheatsheet.md](./CheatSheets/configure-react-cheatsheet.md)__ | __[react-cheatsheet.md](./CheatSheets/react-cheatsheet.md)__ | __[angular-cheatsheet.md](./CheatSheets/angular-cheatsheet.md)__ |
-| __[extension-cheatsheet.md](./CheatSheets/extension-cheatsheet.md)__ | __[sklearn-cheatsheet.md](./CheatSheets/sklearn-cheatsheet.md)__ |  |
+| __[extension-cheatsheet.md](./CheatSheets/extension-cheatsheet.md)__ | __[sklearn-cheatsheet.md](./CheatSheets/sklearn-cheatsheet.md)__ | __[jenkins-cheatsheet.md](./CheatSheets/jenkins-cheatsheet.md)__ |
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A Collection of programming [CheatSheets](./CheatSheets/) for developers to quic
 | __[conda-cheatsheet.md](./CheatSheets/conda-cheatsheet.md)__ | __[pandas-cheatsheet.md](./CheatSheets/pandas-cheatsheet.md)__ | __[numpy-cheatsheet.md](./CheatSheets/Numpy-cheatsheet.md)__ |
 | __[configure-react-cheatsheet.md](./CheatSheets/configure-react-cheatsheet.md)__ | __[react-cheatsheet.md](./CheatSheets/react-cheatsheet.md)__ | __[angular-cheatsheet.md](./CheatSheets/angular-cheatsheet.md)__ |
 | __[extension-cheatsheet.md](./CheatSheets/extension-cheatsheet.md)__ | __[sklearn-cheatsheet.md](./CheatSheets/sklearn-cheatsheet.md)__ | __[jenkins-cheatsheet.md](./CheatSheets/jenkins-cheatsheet.md)__ |
-| __[ansible-cheatsheet.md](./CheatSheets/ansible-cheatsheet.md)__ |  |  |
+| __[ansible-cheatsheet.md](./CheatSheets/Ansible_CheatSheet.md)__ |  |  |
 
 </div>
 
@@ -108,7 +108,7 @@ A Collection of programming [CheatSheets](./CheatSheets/) for developers to quic
 - [yarn-cheatsheet.md](./CheatSheets/yarn-cheatsheet.md)
 - [docker-cheatsheet.md](./CheatSheets/docker-cheatsheet.md)
 - [terraform-cheatsheet.md](./CheatSheets/terraform-cheatsheet.md)
-- [ansible-cheatsheet.md](./CheatSheets/ansible-cheatsheet.md)
+- [ansible-cheatsheet.md](./CheatSheets/Ansible_CheatSheet.md)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A Collection of programming [CheatSheets](./CheatSheets/) for developers to quic
 | __[conda-cheatsheet.md](./CheatSheets/conda-cheatsheet.md)__ | __[pandas-cheatsheet.md](./CheatSheets/pandas-cheatsheet.md)__ | __[numpy-cheatsheet.md](./CheatSheets/Numpy-cheatsheet.md)__ |
 | __[configure-react-cheatsheet.md](./CheatSheets/configure-react-cheatsheet.md)__ | __[react-cheatsheet.md](./CheatSheets/react-cheatsheet.md)__ | __[angular-cheatsheet.md](./CheatSheets/angular-cheatsheet.md)__ |
 | __[extension-cheatsheet.md](./CheatSheets/extension-cheatsheet.md)__ | __[sklearn-cheatsheet.md](./CheatSheets/sklearn-cheatsheet.md)__ | __[jenkins-cheatsheet.md](./CheatSheets/jenkins-cheatsheet.md)__ |
+| __[ansible-cheatsheet.md](./CheatSheets/ansible-cheatsheet.md)__ |  |  |
 
 </div>
 
@@ -107,6 +108,7 @@ A Collection of programming [CheatSheets](./CheatSheets/) for developers to quic
 - [yarn-cheatsheet.md](./CheatSheets/yarn-cheatsheet.md)
 - [docker-cheatsheet.md](./CheatSheets/docker-cheatsheet.md)
 - [terraform-cheatsheet.md](./CheatSheets/terraform-cheatsheet.md)
+- [ansible-cheatsheet.md](./CheatSheets/ansible-cheatsheet.md)
 </details>
 
 <details>


### PR DESCRIPTION
This pull request adds new cheat sheets for Ansible and Jenkins, and expands the existing Docker, Linux, and Git cheat sheets with additional commonly used commands. It also updates the project README to include the new cheat sheets for easier discoverability. The main focus is on improving coverage and usability for developers by providing concise references for essential commands across these tools.

**New Cheat Sheets:**

* Added a comprehensive Ansible cheat sheet covering setup, inventory, ad-hoc commands, playbooks, roles, variables, Ansible Galaxy, Vault, and miscellaneous commands. (`CheatSheets/Ansible_CheatSheet.md`)
* Added a Jenkins cheat sheet with basic management commands for Linux servers. (`CheatSheets/jenkins-cheatsheet.md`)

**Enhancements to Existing Cheat Sheets:**

_Docker:_
* Introduced a new "Manage Compose" section with common Docker Compose commands. [[1]](diffhunk://#diff-7385e375cbc9ecd6faa255412c0e3f8431864abe02959020bfd975dfbe803bdaR12) [[2]](diffhunk://#diff-7385e375cbc9ecd6faa255412c0e3f8431864abe02959020bfd975dfbe803bdaR54-R66)
* Expanded "Manage System" with commands for pruning, network management, and performing a full Docker reset.
* Added a command to display Docker storage usage.

_Git:_
* Added a command sequence for force-pushing after rewriting commit history.

_Linux:_
* Included commands for installing and using `ncdu` for disk usage visualization.

**Documentation and Discoverability:**

* Updated the main `README.md` to list and link the new Ansible and Jenkins cheat sheets in both the visual grid and the detailed list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111)